### PR TITLE
Add https support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 logs
 pkg
 Gemfile.lock
+launch-test.sh

--- a/bin/git-lfs-s3
+++ b/bin/git-lfs-s3
@@ -16,12 +16,16 @@ GitLfsS3::Application.on_authenticate do |username, password|
 end
 
 cert_name = [
-  %w[CN localhost],
+  ["CN", ENV['LFS_CERT_NAME']]
 ]
+
+server_options = {
+  Port: ENV['PORT'] || 8080,
+  SSLEnable: ENV['LFS_USE_SSL'] == 'true' || ENV['LFS_USE_SSL'] == '1',
+  SSLCertName: cert_name
+}
 
 Rack::Handler::WEBrick.run(
   GitLfsS3::Application.new,
-  Port: ENV['PORT'] || 8080,
-  SSLEnable: true,
-  SSLCertName: cert_name
+  server_options
 )

--- a/bin/git-lfs-s3
+++ b/bin/git-lfs-s3
@@ -15,7 +15,13 @@ GitLfsS3::Application.on_authenticate do |username, password|
   username == ENV['USERNAME'] && password == ENV['PASSWORD']
 end
 
+cert_name = [
+  %w[CN localhost],
+]
+
 Rack::Handler::WEBrick.run(
   GitLfsS3::Application.new,
-  Port: ENV['PORT'] || 8080
+  Port: ENV['PORT'] || 8080,
+  SSLEnable: true,
+  SSLCertName: cert_name
 )

--- a/lib/git-lfs-s3.rb
+++ b/lib/git-lfs-s3.rb
@@ -1,6 +1,9 @@
 require 'sinatra/base'
 require 'aws-sdk'
 require 'multi_json'
+require 'webrick'
+require 'webrick/https'
+require 'openssl'
 
 require "git-lfs-s3/aws"
 require "git-lfs-s3/services/upload"


### PR DESCRIPTION
I was able to get HTTPS support working.

This method uses a self-signed certificate. It could be modified to use real certificates pretty easy.

Using a self signed cert requires the following entry in `.gitconfig`:

```
[lfs]
    url = "https://server.com:4000"
[http]
    sslverify = false
```

You should also set the following environment variables when launching the server:

```
 ... (existing documented env. variables)
 LFS_SERVER_URL=https://example.com:4000 \
 RACK_ENV=production \
 LFS_USE_SSL=true \
 LFS_CERT_NAME=example.com \
 gi-lfs-s3
```
